### PR TITLE
Remove unnecessary lines

### DIFF
--- a/Monokakido.popclipext/monokakido.js
+++ b/Monokakido.popclipext/monokakido.js
@@ -1,7 +1,3 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.options = exports.actions = void 0;
-
 // Categories and Scopes list comes from https://www.monokakido.jp/ja/dictionaries/app/usage.html#usage_57
 const { categories, scopes, schemes } = require("./options.json");
 


### PR DESCRIPTION
This pull request is not necessary, but I wanted an excuse to say you did a beautiful job with this extension. 

All this change does is delete the 4 lines at the top, which are not actually needed (they are generated automatically by the TypeScript compiler). It will not affect the function of the extension at all.

Thanks for your engagement with PopClip.
-Nick (PopClip developer)





I'm blown away by your workflow that builds the zip file. (My knowledge of GitHub does not extend to this!)